### PR TITLE
Changes from `coveralls` to `codecov`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,8 @@ jobs:
         # We do this to speed up the build:
         poetry run pytest typesafety -p no:cov -o addopts="" --mypy-ini-file=setup.cfg
 
-    - name: Upload coverage to Coveralls
-      run: |
-        pip install coveralls
-        coveralls
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.8
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -----
 
 [![Build Status](https://travis-ci.org/dry-python/classes.svg?branch=master)](https://travis-ci.org/dry-python/classes)
-[![Coverage Status](https://coveralls.io/repos/github/dry-python/classes/badge.svg?branch=master)](https://coveralls.io/github/dry-python/classes?branch=master)
+[![codecov](https://codecov.io/gh/dry-python/classes/branch/master/graph/badge.svg)](https://codecov.io/gh/dry-python/classes)
 [![Documentation Status](https://readthedocs.org/projects/classes/badge/?version=latest)](https://classes.readthedocs.io/en/latest/?badge=latest)
 [![Python Version](https://img.shields.io/pypi/pyversions/classes.svg)](https://pypi.org/project/classes/)
 [![wemake-python-styleguide](https://img.shields.io/badge/style-wemake-000000.svg)](https://github.com/wemake-services/wemake-python-styleguide)

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ addopts =
   --cov=classes
   --cov-report=term:skip-covered
   --cov-report=html
+  --cov-report=xml
   --cov-branch
   --cov-fail-under=100
   --mypy-ini-file=setup.cfg


### PR DESCRIPTION
Trying to standardize the technologies in our repos I've switched here to use `codecov` since it's used in our most popular project, __returns__ ❤️ !!