### PR TITLE
Fixes that `mypy` plugin was failing  on calling a typeclass without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ We follow Semantic Versions since the `0.1.0` release.
 - Fixes that types referenced in multiple typeclasses
   were not handling `Supports` properly #249
 - Fixes typing bug with `ABC` and mutable typeclass signature #259
+- Fixes that `mypy` plugin was failing
+  on calling a typeclass without arguments #270
 
 
 ## Version 0.3.0

--- a/classes/contrib/mypy/features/typeclass.py
+++ b/classes/contrib/mypy/features/typeclass.py
@@ -272,7 +272,7 @@ def call_signature(ctx: MethodSigContext) -> CallableType:
     assert isinstance(ctx.type, Instance)
 
     real_signature = ctx.type.args[1]
-    if not isinstance(real_signature, CallableType):
+    if not isinstance(real_signature, CallableType) or not ctx.args[0]:
         return ctx.default_signature
 
     passed_type = ctx.api.expr_checker.accept(ctx.args[0][0])  # type: ignore

--- a/typesafety/test_typeclass/test__call__.yml
+++ b/typesafety/test_typeclass/test__call__.yml
@@ -227,3 +227,15 @@
     some(ac)  # ok
     some(bc)  # ok
     some(abc)  # ok
+
+
+- case: typeclass_call_zero_args_regression270
+  disable_cache: false
+  main: |
+    from classes import typeclass
+
+    @typeclass
+    def some(instance) -> int:
+        ...
+
+    some()  # E: Missing positional argument "instance" in call to "__call__" of "_TypeClass"


### PR DESCRIPTION
Closes #270