### PR TITLE
Fix poetry install script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,7 @@ jobs:
 
     - name: Install poetry
       run: |
-        curl -sSL \
-          "https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py" | python
+        curl -sSL https://install.python-poetry.org | python3 -
 
         # Adding `poetry` to `$PATH`:
         echo "$HOME/.poetry/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Fix poetry install script in gitlab CI config.

References:
- https://python-poetry.org/docs/#installing-with-the-official-installer

## Checklist

- [ ] I have double checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation for the changes I have made
- [ ] I have added my changes to the `CHANGELOG.md`

## Related issues

- Closes #494